### PR TITLE
feat: Implement reset password functionality

### DIFF
--- a/lib/core/di/dependency_injectiond.dart
+++ b/lib/core/di/dependency_injectiond.dart
@@ -9,6 +9,8 @@ import '../../features/auth/login/data/repos/login_repo.dart';
 import '../../features/auth/login/logic/login_cubit.dart';
 import '../../features/auth/otp/data/repos/verify_otp_repo.dart';
 import '../../features/auth/otp/logic/verify_otp_cubit.dart';
+import '../../features/auth/reset_password/data/repos/reset_password_repo.dart';
+import '../../features/auth/reset_password/logic/reset_password_cubit.dart';
 import '../../features/auth/sign_up/data/repos/sign_up_repo.dart';
 import '../../features/auth/sign_up/logic/sign_up_cubit.dart';
 
@@ -35,4 +37,9 @@ Future<void> setupGetIt() async {
   // verify otp
   getIt.registerLazySingleton<VerifyOtpRepo>(() => VerifyOtpRepo(getIt()));
   getIt.registerFactory<VerifyOtpCubit>(() => VerifyOtpCubit(getIt()));
+
+  // reset password
+  getIt.registerLazySingleton<ResetPasswordRepo>(
+      () => ResetPasswordRepo(getIt()));
+  getIt.registerFactory<ResetPasswordCubit>(() => ResetPasswordCubit(getIt()));
 }

--- a/lib/core/helpers/helper_methods/show_dialog.dart
+++ b/lib/core/helpers/helper_methods/show_dialog.dart
@@ -13,7 +13,9 @@ import 'package:nexus/core/theming/colors_manager.dart';
 import '../../animations/custom_loading_indicator.dart';
 
 void successDialog(BuildContext context,
-    {required String text, required void Function() onPressed}) {
+    {required String text,
+    required void Function() onPressed,
+    String? buttonText}) {
   showDialog(
     context: context,
     barrierDismissible: false,
@@ -44,7 +46,7 @@ void successDialog(BuildContext context,
           TextButton(
             onPressed: onPressed,
             child: Text(
-              'Continue',
+              buttonText ?? 'Continue',
               style: AppStyles.aldrichRegular16Violet100.copyWith(
                 color: ColorsManager.appColor,
               ),

--- a/lib/core/networking/api_constants.dart
+++ b/lib/core/networking/api_constants.dart
@@ -4,6 +4,7 @@ class ApiConstants {
   static const String signupEndpoint = 'Auth/signup';
   static const String forgotPasswordEndpoint = 'Auth/forgot-password';
   static const String verifyOtpEndpoint = 'Auth/verify-otp';
+  static const String resetPasswordEndpoint = 'Auth/reset-password';
 }
 
 class ApiErrors {

--- a/lib/core/networking/api_service.dart
+++ b/lib/core/networking/api_service.dart
@@ -6,6 +6,7 @@ import 'package:nexus/features/auth/otp/data/models/verify_otp_request_body.dart
 import 'package:nexus/features/auth/sign_up/data/models/sign_up_request_body.dart';
 import 'package:retrofit/retrofit.dart';
 
+import '../../features/auth/reset_password/data/models/reset_password_request_body.dart';
 import 'api_constants.dart';
 part 'api_service.g.dart';
 
@@ -28,5 +29,10 @@ abstract class ApiService {
   @POST(ApiConstants.verifyOtpEndpoint)
   Future<dynamic> verifyOtp(
     @Body() VerifyOtpRequestBody otpRequestBody,
+  );
+
+  @POST(ApiConstants.resetPasswordEndpoint)
+  Future<dynamic> resetPassword(
+    @Body() ResetPasswordRequestBody resetPasswordRequestBody,
   );
 }

--- a/lib/core/networking/api_service.g.dart
+++ b/lib/core/networking/api_service.g.dart
@@ -142,6 +142,35 @@ class _ApiService implements ApiService {
     return _value;
   }
 
+  @override
+  Future<dynamic> resetPassword(
+      ResetPasswordRequestBody resetPasswordRequestBody) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(resetPasswordRequestBody.toJson());
+    final _options = _setStreamType<dynamic>(Options(
+      method: 'POST',
+      headers: _headers,
+      extra: _extra,
+    )
+        .compose(
+          _dio.options,
+          'Auth/reset-password',
+          queryParameters: queryParameters,
+          data: _data,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
+    final _result = await _dio.fetch(_options);
+    final _value = _result.data;
+    return _value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:nexus/core/di/dependency_injectiond.dart';
 import 'package:nexus/features/auth/forgot_password/logic/forgot_password_cubit.dart';
 import 'package:nexus/features/auth/otp/logic/verify_otp_cubit.dart';
+import 'package:nexus/features/auth/reset_password/logic/reset_password_cubit.dart';
 import 'package:nexus/features/auth/sign_up/logic/sign_up_cubit.dart';
 import 'package:nexus/features/layout/app_layout.dart';
 import '../../features/auth/forgot_password/ui/forgot_password_screen.dart';
@@ -39,6 +40,7 @@ class AppRouter {
             create: (context) => getIt<LoginCubit>(),
             child: const LoginScreen(),
           ),
+          settings: settings,
         );
       case Routes.signUpScreen:
         return MaterialPageRoute(
@@ -46,6 +48,7 @@ class AppRouter {
             create: (context) => getIt<SignUpCubit>(),
             child: const SignUpScreen(),
           ),
+          settings: settings,
         );
 
       case Routes.forgotPasswordScreen:
@@ -54,6 +57,7 @@ class AppRouter {
             create: (context) => getIt<ForgotPasswordCubit>(),
             child: const ForgotPasswordScreen(),
           ),
+          settings: settings,
         );
       case Routes.otpScreen:
         final email = arguments as String;
@@ -62,42 +66,92 @@ class AppRouter {
             create: (context) => getIt<VerifyOtpCubit>(),
             child: OtpScreen(email: email),
           ),
+          settings: settings,
         );
       case Routes.resetPasswordScreen:
-        return MaterialPageRoute(builder: (_) => const ResetPasswordScreen());
+        final otp = arguments as String;
+        return MaterialPageRoute(
+          builder: (_) => BlocProvider(
+            create: (context) => getIt<ResetPasswordCubit>(),
+            child: ResetPasswordScreen(otp: otp),
+          ),
+          settings: settings,
+        );
       case Routes.appLayoutScreen:
         return MaterialPageRoute(
           builder: (_) => const AppLayout(),
+          settings: settings,
         );
       case Routes.homeScreen:
-        return MaterialPageRoute(builder: (_) => const HomeScreen());
+        return MaterialPageRoute(
+          builder: (_) => const HomeScreen(),
+          settings: settings,
+        );
       case Routes.subscriptionScreen:
-        return MaterialPageRoute(builder: (_) => const SubscriptionScreen());
+        return MaterialPageRoute(
+          builder: (_) => const SubscriptionScreen(),
+          settings: settings,
+        );
       case Routes.profileScreen:
-        return MaterialPageRoute(builder: (_) => const ProfileScreen());
+        return MaterialPageRoute(
+          builder: (_) => const ProfileScreen(),
+          settings: settings,
+        );
       case Routes.startChatScreen:
-        return MaterialPageRoute(builder: (_) => const StartChatScreen());
+        return MaterialPageRoute(
+          builder: (_) => const StartChatScreen(),
+          settings: settings,
+        );
       case Routes.chatScreen:
-        return MaterialPageRoute(builder: (_) => const ChatScreen());
+        return MaterialPageRoute(
+          builder: (_) => const ChatScreen(),
+          settings: settings,
+        );
       case Routes.settingsScreen:
-        return MaterialPageRoute(builder: (_) => const SettingsScreen());
+        return MaterialPageRoute(
+          builder: (_) => const SettingsScreen(),
+          settings: settings,
+        );
       case Routes.aboutUsScreen:
-        return MaterialPageRoute(builder: (_) => const AboutUsScreen());
+        return MaterialPageRoute(
+          builder: (_) => const AboutUsScreen(),
+          settings: settings,
+        );
       case Routes.contactUsScreen:
-        return MaterialPageRoute(builder: (_) => const ContactUsScreen());
+        return MaterialPageRoute(
+          builder: (_) => const ContactUsScreen(),
+          settings: settings,
+        );
       case Routes.burnScanScreen:
-        return MaterialPageRoute(builder: (_) => const BurnScanScreen());
+        return MaterialPageRoute(
+          builder: (_) => const BurnScanScreen(),
+          settings: settings,
+        );
       case Routes.notificationsScreen:
-        return MaterialPageRoute(builder: (_) => const NotificationsScreen());
+        return MaterialPageRoute(
+          builder: (_) => const NotificationsScreen(),
+          settings: settings,
+        );
       case Routes.editProfileScreen:
-        return MaterialPageRoute(builder: (_) => const EditProfileScreen());
+        return MaterialPageRoute(
+          builder: (_) => const EditProfileScreen(),
+          settings: settings,
+        );
       case Routes.privacyScreen:
-        return MaterialPageRoute(builder: (_) => const PrivacyScreen());
+        return MaterialPageRoute(
+          builder: (_) => const PrivacyScreen(),
+          settings: settings,
+        );
       case Routes.leaderboardScreen:
-        return MaterialPageRoute(builder: (_) => const LeaderboardScreen());
+        return MaterialPageRoute(
+          builder: (_) => const LeaderboardScreen(),
+          settings: settings,
+        );
       case Routes.notificationsSettingsScreen:
         return MaterialPageRoute(
-            builder: (_) => const NotificationsSettingsScreen());
+          builder: (_) => const NotificationsSettingsScreen(),
+          settings: settings,
+        );
 
       default:
         return null;

--- a/lib/features/auth/reset_password/data/models/reset_password_request_body.dart
+++ b/lib/features/auth/reset_password/data/models/reset_password_request_body.dart
@@ -1,0 +1,15 @@
+import 'package:json_annotation/json_annotation.dart';
+part 'reset_password_request_body.g.dart';
+
+@JsonSerializable()
+class ResetPasswordRequestBody {
+  final String otp;
+  final String newPassword;
+
+  ResetPasswordRequestBody({
+    required this.otp,
+    required this.newPassword,
+  });
+
+  Map<String, dynamic> toJson() => _$ResetPasswordRequestBodyToJson(this);
+}

--- a/lib/features/auth/reset_password/data/models/reset_password_request_body.g.dart
+++ b/lib/features/auth/reset_password/data/models/reset_password_request_body.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'reset_password_request_body.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ResetPasswordRequestBody _$ResetPasswordRequestBodyFromJson(
+        Map<String, dynamic> json) =>
+    ResetPasswordRequestBody(
+      otp: json['otp'] as String,
+      newPassword: json['newPassword'] as String,
+    );
+
+Map<String, dynamic> _$ResetPasswordRequestBodyToJson(
+        ResetPasswordRequestBody instance) =>
+    <String, dynamic>{
+      'otp': instance.otp,
+      'newPassword': instance.newPassword,
+    };

--- a/lib/features/auth/reset_password/data/repos/reset_password_repo.dart
+++ b/lib/features/auth/reset_password/data/repos/reset_password_repo.dart
@@ -1,0 +1,21 @@
+import 'package:nexus/core/networking/api_error_handler.dart';
+import 'package:nexus/core/networking/api_result.dart';
+import 'package:nexus/core/networking/api_service.dart';
+import 'package:nexus/features/auth/reset_password/data/models/reset_password_request_body.dart';
+
+class ResetPasswordRepo {
+  final ApiService _apiService;
+
+  ResetPasswordRepo(this._apiService);
+
+  Future<ApiResult<dynamic>> resetPassword(
+      ResetPasswordRequestBody resetPasswordRequestBody) async {
+    try {
+      final response =
+          await _apiService.resetPassword(resetPasswordRequestBody);
+      return ApiResult.success(response);
+    } catch (error) {
+      return ApiResult.failure(ApiErrorHandler.handle(error));
+    }
+  }
+}

--- a/lib/features/auth/reset_password/logic/reset_password_cubit.dart
+++ b/lib/features/auth/reset_password/logic/reset_password_cubit.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:nexus/features/auth/reset_password/data/models/reset_password_request_body.dart';
+import 'package:nexus/features/auth/reset_password/data/repos/reset_password_repo.dart';
+import 'package:nexus/features/auth/reset_password/logic/reset_password_state.dart';
+
+class ResetPasswordCubit extends Cubit<ResetPasswordState> {
+  final ResetPasswordRepo _resetPasswordRepo;
+  ResetPasswordCubit(this._resetPasswordRepo)
+      : super(const ResetPasswordState.resetPasswordInitial());
+
+  TextEditingController newPasswordController = TextEditingController();
+  TextEditingController confirmPasswordController = TextEditingController();
+  final formKey = GlobalKey<FormState>();
+
+  void emitResetPasswordStates(
+      ResetPasswordRequestBody resetPasswordRequestBody) async {
+    emit(const ResetPasswordState.resetPasswordLoading());
+    final response =
+        await _resetPasswordRepo.resetPassword(resetPasswordRequestBody);
+    response.when(
+      success: (data) {
+        emit(ResetPasswordState.resetPasswordSuccess(data));
+      },
+      failure: (errorMessage) {
+        emit(ResetPasswordState.resetPasswordError(errorMessage));
+      },
+    );
+  }
+}

--- a/lib/features/auth/reset_password/logic/reset_password_state.dart
+++ b/lib/features/auth/reset_password/logic/reset_password_state.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'reset_password_state.freezed.dart';
+
+@freezed
+class ResetPasswordState<T> with _$ResetPasswordState<T> {
+  const factory ResetPasswordState.resetPasswordInitial() =
+      _ResetPasswordInitial;
+
+  const factory ResetPasswordState.resetPasswordLoading() =
+      ResetPasswordLoading;
+  const factory ResetPasswordState.resetPasswordSuccess(T data) =
+      ResetPasswordSuccess<T>;
+  const factory ResetPasswordState.resetPasswordError(String message) =
+      ResetPasswordError;
+}

--- a/lib/features/auth/reset_password/logic/reset_password_state.freezed.dart
+++ b/lib/features/auth/reset_password/logic/reset_password_state.freezed.dart
@@ -1,0 +1,658 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'reset_password_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$ResetPasswordState<T> {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() resetPasswordInitial,
+    required TResult Function() resetPasswordLoading,
+    required TResult Function(T data) resetPasswordSuccess,
+    required TResult Function(String message) resetPasswordError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? resetPasswordInitial,
+    TResult? Function()? resetPasswordLoading,
+    TResult? Function(T data)? resetPasswordSuccess,
+    TResult? Function(String message)? resetPasswordError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? resetPasswordInitial,
+    TResult Function()? resetPasswordLoading,
+    TResult Function(T data)? resetPasswordSuccess,
+    TResult Function(String message)? resetPasswordError,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_ResetPasswordInitial<T> value)
+        resetPasswordInitial,
+    required TResult Function(ResetPasswordLoading<T> value)
+        resetPasswordLoading,
+    required TResult Function(ResetPasswordSuccess<T> value)
+        resetPasswordSuccess,
+    required TResult Function(ResetPasswordError<T> value) resetPasswordError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_ResetPasswordInitial<T> value)? resetPasswordInitial,
+    TResult? Function(ResetPasswordLoading<T> value)? resetPasswordLoading,
+    TResult? Function(ResetPasswordSuccess<T> value)? resetPasswordSuccess,
+    TResult? Function(ResetPasswordError<T> value)? resetPasswordError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_ResetPasswordInitial<T> value)? resetPasswordInitial,
+    TResult Function(ResetPasswordLoading<T> value)? resetPasswordLoading,
+    TResult Function(ResetPasswordSuccess<T> value)? resetPasswordSuccess,
+    TResult Function(ResetPasswordError<T> value)? resetPasswordError,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ResetPasswordStateCopyWith<T, $Res> {
+  factory $ResetPasswordStateCopyWith(ResetPasswordState<T> value,
+          $Res Function(ResetPasswordState<T>) then) =
+      _$ResetPasswordStateCopyWithImpl<T, $Res, ResetPasswordState<T>>;
+}
+
+/// @nodoc
+class _$ResetPasswordStateCopyWithImpl<T, $Res,
+        $Val extends ResetPasswordState<T>>
+    implements $ResetPasswordStateCopyWith<T, $Res> {
+  _$ResetPasswordStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ResetPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$ResetPasswordInitialImplCopyWith<T, $Res> {
+  factory _$$ResetPasswordInitialImplCopyWith(
+          _$ResetPasswordInitialImpl<T> value,
+          $Res Function(_$ResetPasswordInitialImpl<T>) then) =
+      __$$ResetPasswordInitialImplCopyWithImpl<T, $Res>;
+}
+
+/// @nodoc
+class __$$ResetPasswordInitialImplCopyWithImpl<T, $Res>
+    extends _$ResetPasswordStateCopyWithImpl<T, $Res,
+        _$ResetPasswordInitialImpl<T>>
+    implements _$$ResetPasswordInitialImplCopyWith<T, $Res> {
+  __$$ResetPasswordInitialImplCopyWithImpl(_$ResetPasswordInitialImpl<T> _value,
+      $Res Function(_$ResetPasswordInitialImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ResetPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$ResetPasswordInitialImpl<T> implements _ResetPasswordInitial<T> {
+  const _$ResetPasswordInitialImpl();
+
+  @override
+  String toString() {
+    return 'ResetPasswordState<$T>.resetPasswordInitial()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ResetPasswordInitialImpl<T>);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() resetPasswordInitial,
+    required TResult Function() resetPasswordLoading,
+    required TResult Function(T data) resetPasswordSuccess,
+    required TResult Function(String message) resetPasswordError,
+  }) {
+    return resetPasswordInitial();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? resetPasswordInitial,
+    TResult? Function()? resetPasswordLoading,
+    TResult? Function(T data)? resetPasswordSuccess,
+    TResult? Function(String message)? resetPasswordError,
+  }) {
+    return resetPasswordInitial?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? resetPasswordInitial,
+    TResult Function()? resetPasswordLoading,
+    TResult Function(T data)? resetPasswordSuccess,
+    TResult Function(String message)? resetPasswordError,
+    required TResult orElse(),
+  }) {
+    if (resetPasswordInitial != null) {
+      return resetPasswordInitial();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_ResetPasswordInitial<T> value)
+        resetPasswordInitial,
+    required TResult Function(ResetPasswordLoading<T> value)
+        resetPasswordLoading,
+    required TResult Function(ResetPasswordSuccess<T> value)
+        resetPasswordSuccess,
+    required TResult Function(ResetPasswordError<T> value) resetPasswordError,
+  }) {
+    return resetPasswordInitial(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_ResetPasswordInitial<T> value)? resetPasswordInitial,
+    TResult? Function(ResetPasswordLoading<T> value)? resetPasswordLoading,
+    TResult? Function(ResetPasswordSuccess<T> value)? resetPasswordSuccess,
+    TResult? Function(ResetPasswordError<T> value)? resetPasswordError,
+  }) {
+    return resetPasswordInitial?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_ResetPasswordInitial<T> value)? resetPasswordInitial,
+    TResult Function(ResetPasswordLoading<T> value)? resetPasswordLoading,
+    TResult Function(ResetPasswordSuccess<T> value)? resetPasswordSuccess,
+    TResult Function(ResetPasswordError<T> value)? resetPasswordError,
+    required TResult orElse(),
+  }) {
+    if (resetPasswordInitial != null) {
+      return resetPasswordInitial(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _ResetPasswordInitial<T> implements ResetPasswordState<T> {
+  const factory _ResetPasswordInitial() = _$ResetPasswordInitialImpl<T>;
+}
+
+/// @nodoc
+abstract class _$$ResetPasswordLoadingImplCopyWith<T, $Res> {
+  factory _$$ResetPasswordLoadingImplCopyWith(
+          _$ResetPasswordLoadingImpl<T> value,
+          $Res Function(_$ResetPasswordLoadingImpl<T>) then) =
+      __$$ResetPasswordLoadingImplCopyWithImpl<T, $Res>;
+}
+
+/// @nodoc
+class __$$ResetPasswordLoadingImplCopyWithImpl<T, $Res>
+    extends _$ResetPasswordStateCopyWithImpl<T, $Res,
+        _$ResetPasswordLoadingImpl<T>>
+    implements _$$ResetPasswordLoadingImplCopyWith<T, $Res> {
+  __$$ResetPasswordLoadingImplCopyWithImpl(_$ResetPasswordLoadingImpl<T> _value,
+      $Res Function(_$ResetPasswordLoadingImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ResetPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$ResetPasswordLoadingImpl<T> implements ResetPasswordLoading<T> {
+  const _$ResetPasswordLoadingImpl();
+
+  @override
+  String toString() {
+    return 'ResetPasswordState<$T>.resetPasswordLoading()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ResetPasswordLoadingImpl<T>);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() resetPasswordInitial,
+    required TResult Function() resetPasswordLoading,
+    required TResult Function(T data) resetPasswordSuccess,
+    required TResult Function(String message) resetPasswordError,
+  }) {
+    return resetPasswordLoading();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? resetPasswordInitial,
+    TResult? Function()? resetPasswordLoading,
+    TResult? Function(T data)? resetPasswordSuccess,
+    TResult? Function(String message)? resetPasswordError,
+  }) {
+    return resetPasswordLoading?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? resetPasswordInitial,
+    TResult Function()? resetPasswordLoading,
+    TResult Function(T data)? resetPasswordSuccess,
+    TResult Function(String message)? resetPasswordError,
+    required TResult orElse(),
+  }) {
+    if (resetPasswordLoading != null) {
+      return resetPasswordLoading();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_ResetPasswordInitial<T> value)
+        resetPasswordInitial,
+    required TResult Function(ResetPasswordLoading<T> value)
+        resetPasswordLoading,
+    required TResult Function(ResetPasswordSuccess<T> value)
+        resetPasswordSuccess,
+    required TResult Function(ResetPasswordError<T> value) resetPasswordError,
+  }) {
+    return resetPasswordLoading(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_ResetPasswordInitial<T> value)? resetPasswordInitial,
+    TResult? Function(ResetPasswordLoading<T> value)? resetPasswordLoading,
+    TResult? Function(ResetPasswordSuccess<T> value)? resetPasswordSuccess,
+    TResult? Function(ResetPasswordError<T> value)? resetPasswordError,
+  }) {
+    return resetPasswordLoading?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_ResetPasswordInitial<T> value)? resetPasswordInitial,
+    TResult Function(ResetPasswordLoading<T> value)? resetPasswordLoading,
+    TResult Function(ResetPasswordSuccess<T> value)? resetPasswordSuccess,
+    TResult Function(ResetPasswordError<T> value)? resetPasswordError,
+    required TResult orElse(),
+  }) {
+    if (resetPasswordLoading != null) {
+      return resetPasswordLoading(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ResetPasswordLoading<T> implements ResetPasswordState<T> {
+  const factory ResetPasswordLoading() = _$ResetPasswordLoadingImpl<T>;
+}
+
+/// @nodoc
+abstract class _$$ResetPasswordSuccessImplCopyWith<T, $Res> {
+  factory _$$ResetPasswordSuccessImplCopyWith(
+          _$ResetPasswordSuccessImpl<T> value,
+          $Res Function(_$ResetPasswordSuccessImpl<T>) then) =
+      __$$ResetPasswordSuccessImplCopyWithImpl<T, $Res>;
+  @useResult
+  $Res call({T data});
+}
+
+/// @nodoc
+class __$$ResetPasswordSuccessImplCopyWithImpl<T, $Res>
+    extends _$ResetPasswordStateCopyWithImpl<T, $Res,
+        _$ResetPasswordSuccessImpl<T>>
+    implements _$$ResetPasswordSuccessImplCopyWith<T, $Res> {
+  __$$ResetPasswordSuccessImplCopyWithImpl(_$ResetPasswordSuccessImpl<T> _value,
+      $Res Function(_$ResetPasswordSuccessImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ResetPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? data = freezed,
+  }) {
+    return _then(_$ResetPasswordSuccessImpl<T>(
+      freezed == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as T,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ResetPasswordSuccessImpl<T> implements ResetPasswordSuccess<T> {
+  const _$ResetPasswordSuccessImpl(this.data);
+
+  @override
+  final T data;
+
+  @override
+  String toString() {
+    return 'ResetPasswordState<$T>.resetPasswordSuccess(data: $data)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ResetPasswordSuccessImpl<T> &&
+            const DeepCollectionEquality().equals(other.data, data));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(data));
+
+  /// Create a copy of ResetPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ResetPasswordSuccessImplCopyWith<T, _$ResetPasswordSuccessImpl<T>>
+      get copyWith => __$$ResetPasswordSuccessImplCopyWithImpl<T,
+          _$ResetPasswordSuccessImpl<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() resetPasswordInitial,
+    required TResult Function() resetPasswordLoading,
+    required TResult Function(T data) resetPasswordSuccess,
+    required TResult Function(String message) resetPasswordError,
+  }) {
+    return resetPasswordSuccess(data);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? resetPasswordInitial,
+    TResult? Function()? resetPasswordLoading,
+    TResult? Function(T data)? resetPasswordSuccess,
+    TResult? Function(String message)? resetPasswordError,
+  }) {
+    return resetPasswordSuccess?.call(data);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? resetPasswordInitial,
+    TResult Function()? resetPasswordLoading,
+    TResult Function(T data)? resetPasswordSuccess,
+    TResult Function(String message)? resetPasswordError,
+    required TResult orElse(),
+  }) {
+    if (resetPasswordSuccess != null) {
+      return resetPasswordSuccess(data);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_ResetPasswordInitial<T> value)
+        resetPasswordInitial,
+    required TResult Function(ResetPasswordLoading<T> value)
+        resetPasswordLoading,
+    required TResult Function(ResetPasswordSuccess<T> value)
+        resetPasswordSuccess,
+    required TResult Function(ResetPasswordError<T> value) resetPasswordError,
+  }) {
+    return resetPasswordSuccess(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_ResetPasswordInitial<T> value)? resetPasswordInitial,
+    TResult? Function(ResetPasswordLoading<T> value)? resetPasswordLoading,
+    TResult? Function(ResetPasswordSuccess<T> value)? resetPasswordSuccess,
+    TResult? Function(ResetPasswordError<T> value)? resetPasswordError,
+  }) {
+    return resetPasswordSuccess?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_ResetPasswordInitial<T> value)? resetPasswordInitial,
+    TResult Function(ResetPasswordLoading<T> value)? resetPasswordLoading,
+    TResult Function(ResetPasswordSuccess<T> value)? resetPasswordSuccess,
+    TResult Function(ResetPasswordError<T> value)? resetPasswordError,
+    required TResult orElse(),
+  }) {
+    if (resetPasswordSuccess != null) {
+      return resetPasswordSuccess(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ResetPasswordSuccess<T> implements ResetPasswordState<T> {
+  const factory ResetPasswordSuccess(final T data) =
+      _$ResetPasswordSuccessImpl<T>;
+
+  T get data;
+
+  /// Create a copy of ResetPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ResetPasswordSuccessImplCopyWith<T, _$ResetPasswordSuccessImpl<T>>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ResetPasswordErrorImplCopyWith<T, $Res> {
+  factory _$$ResetPasswordErrorImplCopyWith(_$ResetPasswordErrorImpl<T> value,
+          $Res Function(_$ResetPasswordErrorImpl<T>) then) =
+      __$$ResetPasswordErrorImplCopyWithImpl<T, $Res>;
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$$ResetPasswordErrorImplCopyWithImpl<T, $Res>
+    extends _$ResetPasswordStateCopyWithImpl<T, $Res,
+        _$ResetPasswordErrorImpl<T>>
+    implements _$$ResetPasswordErrorImplCopyWith<T, $Res> {
+  __$$ResetPasswordErrorImplCopyWithImpl(_$ResetPasswordErrorImpl<T> _value,
+      $Res Function(_$ResetPasswordErrorImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ResetPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_$ResetPasswordErrorImpl<T>(
+      null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ResetPasswordErrorImpl<T> implements ResetPasswordError<T> {
+  const _$ResetPasswordErrorImpl(this.message);
+
+  @override
+  final String message;
+
+  @override
+  String toString() {
+    return 'ResetPasswordState<$T>.resetPasswordError(message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ResetPasswordErrorImpl<T> &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  /// Create a copy of ResetPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ResetPasswordErrorImplCopyWith<T, _$ResetPasswordErrorImpl<T>>
+      get copyWith => __$$ResetPasswordErrorImplCopyWithImpl<T,
+          _$ResetPasswordErrorImpl<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() resetPasswordInitial,
+    required TResult Function() resetPasswordLoading,
+    required TResult Function(T data) resetPasswordSuccess,
+    required TResult Function(String message) resetPasswordError,
+  }) {
+    return resetPasswordError(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? resetPasswordInitial,
+    TResult? Function()? resetPasswordLoading,
+    TResult? Function(T data)? resetPasswordSuccess,
+    TResult? Function(String message)? resetPasswordError,
+  }) {
+    return resetPasswordError?.call(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? resetPasswordInitial,
+    TResult Function()? resetPasswordLoading,
+    TResult Function(T data)? resetPasswordSuccess,
+    TResult Function(String message)? resetPasswordError,
+    required TResult orElse(),
+  }) {
+    if (resetPasswordError != null) {
+      return resetPasswordError(message);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_ResetPasswordInitial<T> value)
+        resetPasswordInitial,
+    required TResult Function(ResetPasswordLoading<T> value)
+        resetPasswordLoading,
+    required TResult Function(ResetPasswordSuccess<T> value)
+        resetPasswordSuccess,
+    required TResult Function(ResetPasswordError<T> value) resetPasswordError,
+  }) {
+    return resetPasswordError(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_ResetPasswordInitial<T> value)? resetPasswordInitial,
+    TResult? Function(ResetPasswordLoading<T> value)? resetPasswordLoading,
+    TResult? Function(ResetPasswordSuccess<T> value)? resetPasswordSuccess,
+    TResult? Function(ResetPasswordError<T> value)? resetPasswordError,
+  }) {
+    return resetPasswordError?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_ResetPasswordInitial<T> value)? resetPasswordInitial,
+    TResult Function(ResetPasswordLoading<T> value)? resetPasswordLoading,
+    TResult Function(ResetPasswordSuccess<T> value)? resetPasswordSuccess,
+    TResult Function(ResetPasswordError<T> value)? resetPasswordError,
+    required TResult orElse(),
+  }) {
+    if (resetPasswordError != null) {
+      return resetPasswordError(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ResetPasswordError<T> implements ResetPasswordState<T> {
+  const factory ResetPasswordError(final String message) =
+      _$ResetPasswordErrorImpl<T>;
+
+  String get message;
+
+  /// Create a copy of ResetPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ResetPasswordErrorImplCopyWith<T, _$ResetPasswordErrorImpl<T>>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/features/auth/reset_password/ui/reset_password_screen.dart
+++ b/lib/features/auth/reset_password/ui/reset_password_screen.dart
@@ -3,7 +3,8 @@ import 'package:nexus/core/constants/assets.dart';
 import 'package:nexus/features/auth/reset_password/ui/widgets/reset_password_body.dart';
 
 class ResetPasswordScreen extends StatelessWidget {
-  const ResetPasswordScreen({super.key});
+  const ResetPasswordScreen({super.key, required this.otp});
+  final String otp;
 
   @override
   Widget build(BuildContext context) {
@@ -14,7 +15,9 @@ class ResetPasswordScreen extends StatelessWidget {
             Image.asset(
               Assets.imagesResetPasswordWavyLine,
             ),
-            const ResetPasswordBody(),
+            ResetPasswordBody(
+              otp: otp,
+            ),
           ],
         ),
       ),

--- a/lib/features/auth/reset_password/ui/widgets/reset_password_bloc_listener.dart
+++ b/lib/features/auth/reset_password/ui/widgets/reset_password_bloc_listener.dart
@@ -2,43 +2,42 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:nexus/core/helpers/base_extensions/context/navigation.dart';
 import 'package:nexus/core/routing/routes.dart';
-import 'package:nexus/features/auth/otp/logic/verify_otp_cubit.dart';
-import 'package:nexus/features/auth/otp/logic/verify_otp_state.dart';
+import 'package:nexus/features/auth/reset_password/logic/reset_password_cubit.dart';
+import 'package:nexus/features/auth/reset_password/logic/reset_password_state.dart';
 
 import '../../../../../core/helpers/helper_methods/show_dialog.dart';
 
-class OtpBlocListener extends StatelessWidget {
-  const OtpBlocListener({super.key});
+class ResetPasswordBlocListener extends StatelessWidget {
+  const ResetPasswordBlocListener({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return BlocListener<VerifyOtpCubit, VerifyOtpState>(
-      listenWhen: (previous, current) {
-        return current is verifyOtpLoading ||
-            current is verifyOtpSuccess ||
-            current is verifyOtpError;
-      },
+    return BlocListener<ResetPasswordCubit, ResetPasswordState>(
+      listenWhen: (previous, current) =>
+          current is ResetPasswordLoading ||
+          current is ResetPasswordSuccess ||
+          current is ResetPasswordError,
       listener: (context, state) {
         state.whenOrNull(
-          verifyOtpLoading: () {
+          resetPasswordLoading: () {
             showCustomLoadingIndicator(context);
           },
-          verifyOtpSuccess: (data) {
+          resetPasswordSuccess: (data) {
             context.pop();
             successDialog(
               context,
               text: data,
+              buttonText: 'Ok',
               onPressed: () {
                 context.pushNamedAndRemoveUntil(
-                  Routes.resetPasswordScreen,
+                  Routes.loginScreen,
                   predicate: (route) =>
                       route.settings.name == Routes.loginScreen,
-                  arguments: context.read<VerifyOtpCubit>().pinController.text,
                 );
               },
             );
           },
-          verifyOtpError: (errorMessage) {
+          resetPasswordError: (errorMessage) {
             context.pop();
             setupErrorState(context, errorMessage);
           },

--- a/lib/features/auth/reset_password/ui/widgets/reset_password_body.dart
+++ b/lib/features/auth/reset_password/ui/widgets/reset_password_body.dart
@@ -1,10 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:nexus/core/widgets/custom_header.dart';
 import 'package:nexus/core/helpers/helper_methods/spacing.dart';
-import 'package:nexus/features/auth/reset_password/ui/widgets/reset_password_form_with_button.dart';
+import 'package:nexus/features/auth/reset_password/data/models/reset_password_request_body.dart';
+import 'package:nexus/features/auth/reset_password/logic/reset_password_cubit.dart';
+import 'package:nexus/features/auth/reset_password/ui/widgets/reset_password_form.dart';
+
+import '../../../../../core/widgets/app_text_button.dart';
+import 'reset_password_bloc_listener.dart';
 
 class ResetPasswordBody extends StatelessWidget {
-  const ResetPasswordBody({super.key});
+  const ResetPasswordBody({super.key, required this.otp});
+  final String otp;
 
   @override
   Widget build(BuildContext context) {
@@ -15,12 +22,29 @@ class ResetPasswordBody extends StatelessWidget {
           verticalSpace(29),
           const CustomHeader(text: 'Reset Password'),
           verticalSpace(212),
-          const ResetPasswordFormWithButton(
-            email: '',
-            otp: '',
+          const ResetPasswordForm(),
+          verticalSpace(68),
+          AppTextButton(
+            onPressed: () {
+              validateThenResetPassword(context);
+            },
+            text: 'Confirm',
           ),
+          const ResetPasswordBlocListener(),
         ],
       ),
     );
+  }
+
+  void validateThenResetPassword(BuildContext context) {
+    if (context.read<ResetPasswordCubit>().formKey.currentState!.validate()) {
+      context.read<ResetPasswordCubit>().emitResetPasswordStates(
+            ResetPasswordRequestBody(
+              otp: otp,
+              newPassword:
+                  context.read<ResetPasswordCubit>().newPasswordController.text,
+            ),
+          );
+    }
   }
 }

--- a/lib/features/auth/reset_password/ui/widgets/reset_password_form.dart
+++ b/lib/features/auth/reset_password/ui/widgets/reset_password_form.dart
@@ -1,57 +1,36 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:flutter/material.dart';
 import 'package:nexus/core/constants/assets.dart';
 import 'package:nexus/core/helpers/base_extensions/context/padding.dart';
-import 'package:nexus/core/widgets/app_text_button.dart';
 import 'package:nexus/core/widgets/auth_text_form_field.dart';
 import 'package:nexus/core/helpers/helper_methods/spacing.dart';
 import 'package:nexus/core/helpers/helper_methods/validators.dart';
 
-class ResetPasswordFormWithButton extends StatefulWidget {
-  final String email;
-  final String otp;
+import '../../logic/reset_password_cubit.dart';
 
-  const ResetPasswordFormWithButton(
-      {super.key, required this.email, required this.otp});
+class ResetPasswordForm extends StatefulWidget {
+  const ResetPasswordForm({
+    super.key,
+  });
 
   @override
-  State<ResetPasswordFormWithButton> createState() => _ResetPasswordFormState();
+  State<ResetPasswordForm> createState() => _ResetPasswordFormState();
 }
 
-class _ResetPasswordFormState extends State<ResetPasswordFormWithButton> {
-  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
-  final TextEditingController _newPasswordController = TextEditingController();
-  final TextEditingController _confirmPasswordController =
-      TextEditingController();
-
-  void _submitForm() {
-    if (_formKey.currentState!.validate()) {
-      // final String newPassword = _newPasswordController.text;
-      // final String confirmPassword = _confirmPasswordController.text;
-      // final String email = widget.email;
-      // final String otp = widget.otp;
-
-      // final requestModel = ResetPasswordRequestModel(
-      //   email: email,
-      //   otp: otp,
-      //   password: newPassword,
-      //   confirmPassword: confirmPassword,
-      // );
-      // context.read<ResetPasswordCubit>().resetPassword(requestModel);
-    }
-  }
-
+class _ResetPasswordFormState extends State<ResetPasswordForm> {
   @override
   Widget build(BuildContext context) {
     return Form(
-      key: _formKey,
+      key: context.read<ResetPasswordCubit>().formKey,
       child: Column(
         children: [
           Padding(
             padding: context.horizontal(24.w),
             child: AuthTextFormField(
-              controller: _newPasswordController,
+              controller:
+                  context.read<ResetPasswordCubit>().newPasswordController,
               label: 'Password',
               hint: 'At least 8 characters',
               isPassword: true,
@@ -68,7 +47,8 @@ class _ResetPasswordFormState extends State<ResetPasswordFormWithButton> {
           Padding(
             padding: context.horizontal(24.w),
             child: AuthTextFormField(
-              controller: _confirmPasswordController,
+              controller:
+                  context.read<ResetPasswordCubit>().confirmPasswordController,
               label: 'Confirm Password',
               hint: 'Re-enter your password',
               isPassword: true,
@@ -78,14 +58,11 @@ class _ResetPasswordFormState extends State<ResetPasswordFormWithButton> {
                 width: 16,
               ),
               validator: (value) => Validators.validateConfirmPassword(
-                  value, _newPasswordController.text),
+                value,
+                context.read<ResetPasswordCubit>().newPasswordController.text,
+              ),
               onSaved: (value) {},
             ),
-          ),
-          verticalSpace(68),
-          AppTextButton(
-            onPressed: _submitForm,
-            text: 'Confirm',
           ),
         ],
       ),


### PR DESCRIPTION
- Added reset password API endpoint and corresponding request model.
- Created ResetPasswordCubit to manage reset password state and logic.
- Developed ResetPasswordScreen with form validation and submission.
- Integrated BlocListener for handling loading, success, and error states during password reset.
- Updated navigation to include reset password flow from OTP verification.
- Refactored success dialog to accept custom button text.
- Removed unused ResetPasswordFormWithButton widget and replaced with ResetPasswordForm.