### PR TITLE
feat: add resend OTP code functionality

### DIFF
--- a/lib/core/di/dependency_injectiond.dart
+++ b/lib/core/di/dependency_injectiond.dart
@@ -29,8 +29,8 @@ Future<void> setupGetIt() async {
   // forgot password
   getIt.registerLazySingleton<ForgotPasswordRepo>(
       () => ForgotPasswordRepo(getIt()));
-  getIt
-      .registerFactory<ForgotPasswordCubit>(() => ForgotPasswordCubit(getIt()));
+  getIt.registerLazySingleton<ForgotPasswordCubit>(
+      () => ForgotPasswordCubit(getIt()));
 
   // verify otp
   getIt.registerLazySingleton<VerifyOtpRepo>(() => VerifyOtpRepo(getIt()));

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -61,8 +61,15 @@ class AppRouter {
       case Routes.otpScreen:
         final email = arguments as String;
         return MaterialPageRoute(
-          builder: (_) => BlocProvider(
-            create: (context) => getIt<VerifyOtpCubit>(),
+          builder: (_) => MultiBlocProvider(
+            providers: [
+              BlocProvider(
+                create: (context) => getIt<VerifyOtpCubit>(),
+              ),
+              BlocProvider(
+                create: (context) => getIt<ForgotPasswordCubit>(),
+              ),
+            ],
             child: OtpScreen(email: email),
           ),
           settings: settings,

--- a/lib/features/auth/otp/ui/widgets/resend_otp_text.dart
+++ b/lib/features/auth/otp/ui/widgets/resend_otp_text.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:nexus/core/theming/app_styles.dart';
 import 'package:nexus/core/theming/colors_manager.dart';
+import 'package:nexus/features/auth/forgot_password/logic/forgot_password_cubit.dart';
 
 class ResendOtpText extends StatelessWidget {
   const ResendOtpText({super.key});
@@ -22,7 +24,7 @@ class ResendOtpText extends StatelessWidget {
             ),
             recognizer: TapGestureRecognizer()
               ..onTap = () {
-                //  resend logic
+                context.read<ForgotPasswordCubit>().emitForgotPasswordStates();
               },
           ),
         ],


### PR DESCRIPTION
- Register ForgotPasswordCubit as a Singleton
- Provide ForgotPasswordCubit to OtpScreen by MultiBlocProvider
- Add onTap recognizer to the 'Resend' TextSpan to trigger the resend functionality