### PR TITLE
feat: Implement burn analysis feature with image upload and classification

### DIFF
--- a/lib/core/di/dependency_injectiond.dart
+++ b/lib/core/di/dependency_injectiond.dart
@@ -13,6 +13,8 @@ import '../../features/auth/reset_password/data/repos/reset_password_repo.dart';
 import '../../features/auth/reset_password/logic/reset_password_cubit.dart';
 import '../../features/auth/sign_up/data/repos/sign_up_repo.dart';
 import '../../features/auth/sign_up/logic/sign_up_cubit.dart';
+import '../../features/burn_scan/data/repos/burn_scan_repo.dart';
+import '../../features/burn_scan/logic/burn_scan_cubit.dart';
 import '../../features/leaderboard/data/repos/leaderboard_repo.dart';
 import '../../features/leaderboard/logic/leaderboard_cubit.dart';
 
@@ -48,4 +50,8 @@ Future<void> setupGetIt() async {
   // leaderboard
   getIt.registerLazySingleton<LeaderboardRepo>(() => LeaderboardRepo(getIt()));
   getIt.registerFactory<LeaderboardCubit>(() => LeaderboardCubit(getIt()));
+
+  // burn scan
+  getIt.registerLazySingleton<BurnScanRepo>(() => BurnScanRepo(getIt()));
+  getIt.registerFactory<BurnScanCubit>(() => BurnScanCubit(getIt()));
 }

--- a/lib/core/networking/api_constants.dart
+++ b/lib/core/networking/api_constants.dart
@@ -1,5 +1,7 @@
 class ApiConstants {
   static const String baseUrl = 'http://nexus-apis.runasp.net/api/';
+  static const String burnClassificationUrl =
+      'https://skinburn-api.onrender.com/predictApi';
   static const String loginEndpoint = 'Auth/signin';
   static const String signupEndpoint = 'Auth/signup';
   static const String forgotPasswordEndpoint = 'Auth/forgot-password';

--- a/lib/core/networking/api_error_handler.dart
+++ b/lib/core/networking/api_error_handler.dart
@@ -21,9 +21,11 @@ class ApiErrorHandler {
         case DioExceptionType.badCertificate:
           return "Bad certificate from the server";
         case DioExceptionType.badResponse:
-          return error.response?.data ?? "Bad response from server";
+          return error.response?.data?.toString() ??
+              "Received an invalid response from the server";
         case DioExceptionType.sendTimeout:
           return "Send timeout in connection with the server";
+
         default:
           return "Something went wrong";
       }

--- a/lib/core/networking/api_service.dart
+++ b/lib/core/networking/api_service.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:dio/dio.dart';
 import 'package:nexus/features/auth/forgot_password/data/models/forgot_password_request_body.dart';
 import 'package:nexus/features/auth/login/data/models/login_request_body.dart';
@@ -8,6 +9,7 @@ import 'package:nexus/features/leaderboard/data/models/leaderboard_response_mode
 import 'package:retrofit/retrofit.dart';
 
 import '../../features/auth/reset_password/data/models/reset_password_request_body.dart';
+import '../../features/burn_scan/data/models/burn_analysis_response_model.dart';
 import 'api_constants.dart';
 part 'api_service.g.dart';
 
@@ -39,4 +41,10 @@ abstract class ApiService {
 
   @GET(ApiConstants.leaderboardEndpoint)
   Future<List<LeaderboardUser>> getLeaderboardUsersList();
+
+  @POST(ApiConstants.burnClassificationUrl)
+  @MultiPart()
+  Future<BurnAnalysisResponseModel> analyzeBurn(
+    @Part(name: "fileup") File image,
+  );
 }

--- a/lib/core/networking/api_service.g.dart
+++ b/lib/core/networking/api_service.g.dart
@@ -207,6 +207,47 @@ class _ApiService implements ApiService {
     return _value;
   }
 
+  @override
+  Future<BurnAnalysisResponseModel> analyzeBurn(File image) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = FormData();
+    _data.files.add(MapEntry(
+      'fileup',
+      MultipartFile.fromFileSync(
+        image.path,
+        filename: image.path.split(Platform.pathSeparator).last,
+      ),
+    ));
+    final _options = _setStreamType<BurnAnalysisResponseModel>(Options(
+      method: 'POST',
+      headers: _headers,
+      extra: _extra,
+      contentType: 'multipart/form-data',
+    )
+        .compose(
+          _dio.options,
+          'https://skinburn-api.onrender.com/predictApi',
+          queryParameters: queryParameters,
+          data: _data,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late BurnAnalysisResponseModel _value;
+    try {
+      _value = BurnAnalysisResponseModel.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -5,6 +5,7 @@ import 'package:nexus/features/auth/forgot_password/logic/forgot_password_cubit.
 import 'package:nexus/features/auth/otp/logic/verify_otp_cubit.dart';
 import 'package:nexus/features/auth/reset_password/logic/reset_password_cubit.dart';
 import 'package:nexus/features/auth/sign_up/logic/sign_up_cubit.dart';
+import 'package:nexus/features/burn_scan/logic/burn_scan_cubit.dart';
 import 'package:nexus/features/burn_scan/ui/screens/classification_screen.dart';
 import 'package:nexus/features/layout/app_layout.dart';
 import '../../features/auth/forgot_password/ui/forgot_password_screen.dart';
@@ -13,6 +14,7 @@ import '../../features/auth/login/ui/login_screen.dart';
 import '../../features/auth/otp/ui/otp_screen.dart';
 import '../../features/auth/reset_password/ui/reset_password_screen.dart';
 import '../../features/auth/sign_up/ui/sign_up_screen.dart';
+import '../../features/burn_scan/data/models/burn_analysis_response_model.dart';
 import '../../features/burn_scan/ui/screens/burn_scan_screen.dart';
 import '../../features/chatbot/screens/chat_screen.dart';
 import '../../features/chatbot/screens/start_chat_screen.dart';
@@ -133,7 +135,10 @@ class AppRouter {
         );
       case Routes.burnScanScreen:
         return MaterialPageRoute(
-          builder: (_) => const BurnScanScreen(),
+          builder: (_) => BlocProvider(
+            create: (context) => getIt<BurnScanCubit>(),
+            child: const BurnScanScreen(),
+          ),
           settings: settings,
         );
       case Routes.notificationsScreen:
@@ -166,8 +171,14 @@ class AppRouter {
           settings: settings,
         );
       case Routes.classificationScreen:
+        final burnDetails = arguments as BurnResult;
         return MaterialPageRoute(
-          builder: (_) => const ClassificationScreen(),
+          builder: (_) => BlocProvider(
+            create: (context) => getIt<BurnScanCubit>(),
+            child: ClassificationScreen(
+              burnDetails: burnDetails,
+            ),
+          ),
           settings: settings,
         );
 

--- a/lib/features/burn_scan/data/models/burn_analysis_response_model.dart
+++ b/lib/features/burn_scan/data/models/burn_analysis_response_model.dart
@@ -1,0 +1,57 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'burn_analysis_response_model.g.dart';
+
+// This is the new top-level response model
+@JsonSerializable()
+class BurnAnalysisResponseModel {
+  final bool error;
+  final BurnResult result;
+  final String disclaimer;
+
+  BurnAnalysisResponseModel({
+    required this.error,
+    required this.result,
+    required this.disclaimer,
+  });
+
+  factory BurnAnalysisResponseModel.fromJson(Map<String, dynamic> json) =>
+      _$BurnAnalysisResponseModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$BurnAnalysisResponseModelToJson(this);
+}
+
+// This model represents the "result" object in the JSON
+@JsonSerializable()
+class BurnResult {
+  final String classification;
+  final String color;
+  final String confidence;
+  final String description;
+  final bool emergency;
+  @JsonKey(name: 'healing_time')
+  final String healingTime;
+  final String severity;
+  final List<String> symptoms;
+  final List<String> treatment;
+  @JsonKey(name: 'when_to_seek_help')
+  final String whenToSeekHelp;
+
+  BurnResult({
+    required this.classification,
+    required this.color,
+    required this.confidence,
+    required this.description,
+    required this.emergency,
+    required this.healingTime,
+    required this.severity,
+    required this.symptoms,
+    required this.treatment,
+    required this.whenToSeekHelp,
+  });
+
+  factory BurnResult.fromJson(Map<String, dynamic> json) =>
+      _$BurnResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$BurnResultToJson(this);
+}

--- a/lib/features/burn_scan/data/models/burn_analysis_response_model.g.dart
+++ b/lib/features/burn_scan/data/models/burn_analysis_response_model.g.dart
@@ -1,0 +1,52 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'burn_analysis_response_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+BurnAnalysisResponseModel _$BurnAnalysisResponseModelFromJson(
+        Map<String, dynamic> json) =>
+    BurnAnalysisResponseModel(
+      error: json['error'] as bool,
+      result: BurnResult.fromJson(json['result'] as Map<String, dynamic>),
+      disclaimer: json['disclaimer'] as String,
+    );
+
+Map<String, dynamic> _$BurnAnalysisResponseModelToJson(
+        BurnAnalysisResponseModel instance) =>
+    <String, dynamic>{
+      'error': instance.error,
+      'result': instance.result,
+      'disclaimer': instance.disclaimer,
+    };
+
+BurnResult _$BurnResultFromJson(Map<String, dynamic> json) => BurnResult(
+      classification: json['classification'] as String,
+      color: json['color'] as String,
+      confidence: json['confidence'] as String,
+      description: json['description'] as String,
+      emergency: json['emergency'] as bool,
+      healingTime: json['healing_time'] as String,
+      severity: json['severity'] as String,
+      symptoms:
+          (json['symptoms'] as List<dynamic>).map((e) => e as String).toList(),
+      treatment:
+          (json['treatment'] as List<dynamic>).map((e) => e as String).toList(),
+      whenToSeekHelp: json['when_to_seek_help'] as String,
+    );
+
+Map<String, dynamic> _$BurnResultToJson(BurnResult instance) =>
+    <String, dynamic>{
+      'classification': instance.classification,
+      'color': instance.color,
+      'confidence': instance.confidence,
+      'description': instance.description,
+      'emergency': instance.emergency,
+      'healing_time': instance.healingTime,
+      'severity': instance.severity,
+      'symptoms': instance.symptoms,
+      'treatment': instance.treatment,
+      'when_to_seek_help': instance.whenToSeekHelp,
+    };

--- a/lib/features/burn_scan/data/repos/burn_scan_repo.dart
+++ b/lib/features/burn_scan/data/repos/burn_scan_repo.dart
@@ -1,0 +1,20 @@
+import 'dart:io';
+
+import 'package:nexus/core/networking/api_result.dart';
+import 'package:nexus/core/networking/api_service.dart';
+import 'package:nexus/features/burn_scan/data/models/burn_analysis_response_model.dart';
+
+import '../../../../core/networking/api_error_handler.dart';
+
+class BurnScanRepo {
+  final ApiService _apiService;
+  BurnScanRepo(this._apiService);
+  Future<ApiResult<BurnAnalysisResponseModel>> analyzeBurn(File image) async {
+    try {
+      final response = await _apiService.analyzeBurn(image);
+      return ApiResult.success(response);
+    } catch (error) {
+      return ApiResult.failure(ApiErrorHandler.handle(error));
+    }
+  }
+}

--- a/lib/features/burn_scan/logic/burn_scan_cubit.dart
+++ b/lib/features/burn_scan/logic/burn_scan_cubit.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:nexus/features/burn_scan/data/repos/burn_scan_repo.dart';
+import 'package:nexus/features/burn_scan/logic/burn_scan_state.dart';
+
+class BurnScanCubit extends Cubit<BurnScanState> {
+  final BurnScanRepo _burnScanRepo;
+  BurnScanCubit(this._burnScanRepo)
+      : super(const BurnScanState.burnScanInitial());
+  void analyzeBurn(File image) async {
+    emit(const BurnScanState.burnScanLoading());
+    final result = await _burnScanRepo.analyzeBurn(image);
+    result.when(
+      success: (burnAnalysisResponse) {
+        emit(BurnScanState.burnScanSuccess(burnAnalysisResponse));
+      },
+      failure: (error) {
+        emit(BurnScanState.burnScanError(error));
+      },
+    );
+  }
+}

--- a/lib/features/burn_scan/logic/burn_scan_state.dart
+++ b/lib/features/burn_scan/logic/burn_scan_state.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nexus/features/burn_scan/data/models/burn_analysis_response_model.dart';
+part 'burn_scan_state.freezed.dart';
+
+@freezed
+class BurnScanState<T> with _$BurnScanState<T> {
+  const factory BurnScanState.burnScanInitial() = _burnScanInitial;
+  const factory BurnScanState.burnScanLoading() = burnScanLoading;
+  const factory BurnScanState.burnScanSuccess(
+      BurnAnalysisResponseModel response) = burnScanSuccess;
+  const factory BurnScanState.burnScanError(String error) = burnScanError;
+}

--- a/lib/features/burn_scan/logic/burn_scan_state.freezed.dart
+++ b/lib/features/burn_scan/logic/burn_scan_state.freezed.dart
@@ -1,0 +1,637 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'burn_scan_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$BurnScanState<T> {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() burnScanInitial,
+    required TResult Function() burnScanLoading,
+    required TResult Function(BurnAnalysisResponseModel response)
+        burnScanSuccess,
+    required TResult Function(String error) burnScanError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? burnScanInitial,
+    TResult? Function()? burnScanLoading,
+    TResult? Function(BurnAnalysisResponseModel response)? burnScanSuccess,
+    TResult? Function(String error)? burnScanError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? burnScanInitial,
+    TResult Function()? burnScanLoading,
+    TResult Function(BurnAnalysisResponseModel response)? burnScanSuccess,
+    TResult Function(String error)? burnScanError,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_burnScanInitial<T> value) burnScanInitial,
+    required TResult Function(burnScanLoading<T> value) burnScanLoading,
+    required TResult Function(burnScanSuccess<T> value) burnScanSuccess,
+    required TResult Function(burnScanError<T> value) burnScanError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_burnScanInitial<T> value)? burnScanInitial,
+    TResult? Function(burnScanLoading<T> value)? burnScanLoading,
+    TResult? Function(burnScanSuccess<T> value)? burnScanSuccess,
+    TResult? Function(burnScanError<T> value)? burnScanError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_burnScanInitial<T> value)? burnScanInitial,
+    TResult Function(burnScanLoading<T> value)? burnScanLoading,
+    TResult Function(burnScanSuccess<T> value)? burnScanSuccess,
+    TResult Function(burnScanError<T> value)? burnScanError,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $BurnScanStateCopyWith<T, $Res> {
+  factory $BurnScanStateCopyWith(
+          BurnScanState<T> value, $Res Function(BurnScanState<T>) then) =
+      _$BurnScanStateCopyWithImpl<T, $Res, BurnScanState<T>>;
+}
+
+/// @nodoc
+class _$BurnScanStateCopyWithImpl<T, $Res, $Val extends BurnScanState<T>>
+    implements $BurnScanStateCopyWith<T, $Res> {
+  _$BurnScanStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of BurnScanState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$burnScanInitialImplCopyWith<T, $Res> {
+  factory _$$burnScanInitialImplCopyWith(_$burnScanInitialImpl<T> value,
+          $Res Function(_$burnScanInitialImpl<T>) then) =
+      __$$burnScanInitialImplCopyWithImpl<T, $Res>;
+}
+
+/// @nodoc
+class __$$burnScanInitialImplCopyWithImpl<T, $Res>
+    extends _$BurnScanStateCopyWithImpl<T, $Res, _$burnScanInitialImpl<T>>
+    implements _$$burnScanInitialImplCopyWith<T, $Res> {
+  __$$burnScanInitialImplCopyWithImpl(_$burnScanInitialImpl<T> _value,
+      $Res Function(_$burnScanInitialImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of BurnScanState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$burnScanInitialImpl<T> implements _burnScanInitial<T> {
+  const _$burnScanInitialImpl();
+
+  @override
+  String toString() {
+    return 'BurnScanState<$T>.burnScanInitial()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$burnScanInitialImpl<T>);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() burnScanInitial,
+    required TResult Function() burnScanLoading,
+    required TResult Function(BurnAnalysisResponseModel response)
+        burnScanSuccess,
+    required TResult Function(String error) burnScanError,
+  }) {
+    return burnScanInitial();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? burnScanInitial,
+    TResult? Function()? burnScanLoading,
+    TResult? Function(BurnAnalysisResponseModel response)? burnScanSuccess,
+    TResult? Function(String error)? burnScanError,
+  }) {
+    return burnScanInitial?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? burnScanInitial,
+    TResult Function()? burnScanLoading,
+    TResult Function(BurnAnalysisResponseModel response)? burnScanSuccess,
+    TResult Function(String error)? burnScanError,
+    required TResult orElse(),
+  }) {
+    if (burnScanInitial != null) {
+      return burnScanInitial();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_burnScanInitial<T> value) burnScanInitial,
+    required TResult Function(burnScanLoading<T> value) burnScanLoading,
+    required TResult Function(burnScanSuccess<T> value) burnScanSuccess,
+    required TResult Function(burnScanError<T> value) burnScanError,
+  }) {
+    return burnScanInitial(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_burnScanInitial<T> value)? burnScanInitial,
+    TResult? Function(burnScanLoading<T> value)? burnScanLoading,
+    TResult? Function(burnScanSuccess<T> value)? burnScanSuccess,
+    TResult? Function(burnScanError<T> value)? burnScanError,
+  }) {
+    return burnScanInitial?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_burnScanInitial<T> value)? burnScanInitial,
+    TResult Function(burnScanLoading<T> value)? burnScanLoading,
+    TResult Function(burnScanSuccess<T> value)? burnScanSuccess,
+    TResult Function(burnScanError<T> value)? burnScanError,
+    required TResult orElse(),
+  }) {
+    if (burnScanInitial != null) {
+      return burnScanInitial(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _burnScanInitial<T> implements BurnScanState<T> {
+  const factory _burnScanInitial() = _$burnScanInitialImpl<T>;
+}
+
+/// @nodoc
+abstract class _$$burnScanLoadingImplCopyWith<T, $Res> {
+  factory _$$burnScanLoadingImplCopyWith(_$burnScanLoadingImpl<T> value,
+          $Res Function(_$burnScanLoadingImpl<T>) then) =
+      __$$burnScanLoadingImplCopyWithImpl<T, $Res>;
+}
+
+/// @nodoc
+class __$$burnScanLoadingImplCopyWithImpl<T, $Res>
+    extends _$BurnScanStateCopyWithImpl<T, $Res, _$burnScanLoadingImpl<T>>
+    implements _$$burnScanLoadingImplCopyWith<T, $Res> {
+  __$$burnScanLoadingImplCopyWithImpl(_$burnScanLoadingImpl<T> _value,
+      $Res Function(_$burnScanLoadingImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of BurnScanState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$burnScanLoadingImpl<T> implements burnScanLoading<T> {
+  const _$burnScanLoadingImpl();
+
+  @override
+  String toString() {
+    return 'BurnScanState<$T>.burnScanLoading()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$burnScanLoadingImpl<T>);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() burnScanInitial,
+    required TResult Function() burnScanLoading,
+    required TResult Function(BurnAnalysisResponseModel response)
+        burnScanSuccess,
+    required TResult Function(String error) burnScanError,
+  }) {
+    return burnScanLoading();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? burnScanInitial,
+    TResult? Function()? burnScanLoading,
+    TResult? Function(BurnAnalysisResponseModel response)? burnScanSuccess,
+    TResult? Function(String error)? burnScanError,
+  }) {
+    return burnScanLoading?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? burnScanInitial,
+    TResult Function()? burnScanLoading,
+    TResult Function(BurnAnalysisResponseModel response)? burnScanSuccess,
+    TResult Function(String error)? burnScanError,
+    required TResult orElse(),
+  }) {
+    if (burnScanLoading != null) {
+      return burnScanLoading();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_burnScanInitial<T> value) burnScanInitial,
+    required TResult Function(burnScanLoading<T> value) burnScanLoading,
+    required TResult Function(burnScanSuccess<T> value) burnScanSuccess,
+    required TResult Function(burnScanError<T> value) burnScanError,
+  }) {
+    return burnScanLoading(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_burnScanInitial<T> value)? burnScanInitial,
+    TResult? Function(burnScanLoading<T> value)? burnScanLoading,
+    TResult? Function(burnScanSuccess<T> value)? burnScanSuccess,
+    TResult? Function(burnScanError<T> value)? burnScanError,
+  }) {
+    return burnScanLoading?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_burnScanInitial<T> value)? burnScanInitial,
+    TResult Function(burnScanLoading<T> value)? burnScanLoading,
+    TResult Function(burnScanSuccess<T> value)? burnScanSuccess,
+    TResult Function(burnScanError<T> value)? burnScanError,
+    required TResult orElse(),
+  }) {
+    if (burnScanLoading != null) {
+      return burnScanLoading(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class burnScanLoading<T> implements BurnScanState<T> {
+  const factory burnScanLoading() = _$burnScanLoadingImpl<T>;
+}
+
+/// @nodoc
+abstract class _$$burnScanSuccessImplCopyWith<T, $Res> {
+  factory _$$burnScanSuccessImplCopyWith(_$burnScanSuccessImpl<T> value,
+          $Res Function(_$burnScanSuccessImpl<T>) then) =
+      __$$burnScanSuccessImplCopyWithImpl<T, $Res>;
+  @useResult
+  $Res call({BurnAnalysisResponseModel response});
+}
+
+/// @nodoc
+class __$$burnScanSuccessImplCopyWithImpl<T, $Res>
+    extends _$BurnScanStateCopyWithImpl<T, $Res, _$burnScanSuccessImpl<T>>
+    implements _$$burnScanSuccessImplCopyWith<T, $Res> {
+  __$$burnScanSuccessImplCopyWithImpl(_$burnScanSuccessImpl<T> _value,
+      $Res Function(_$burnScanSuccessImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of BurnScanState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? response = null,
+  }) {
+    return _then(_$burnScanSuccessImpl<T>(
+      null == response
+          ? _value.response
+          : response // ignore: cast_nullable_to_non_nullable
+              as BurnAnalysisResponseModel,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$burnScanSuccessImpl<T> implements burnScanSuccess<T> {
+  const _$burnScanSuccessImpl(this.response);
+
+  @override
+  final BurnAnalysisResponseModel response;
+
+  @override
+  String toString() {
+    return 'BurnScanState<$T>.burnScanSuccess(response: $response)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$burnScanSuccessImpl<T> &&
+            (identical(other.response, response) ||
+                other.response == response));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, response);
+
+  /// Create a copy of BurnScanState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$burnScanSuccessImplCopyWith<T, _$burnScanSuccessImpl<T>> get copyWith =>
+      __$$burnScanSuccessImplCopyWithImpl<T, _$burnScanSuccessImpl<T>>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() burnScanInitial,
+    required TResult Function() burnScanLoading,
+    required TResult Function(BurnAnalysisResponseModel response)
+        burnScanSuccess,
+    required TResult Function(String error) burnScanError,
+  }) {
+    return burnScanSuccess(response);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? burnScanInitial,
+    TResult? Function()? burnScanLoading,
+    TResult? Function(BurnAnalysisResponseModel response)? burnScanSuccess,
+    TResult? Function(String error)? burnScanError,
+  }) {
+    return burnScanSuccess?.call(response);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? burnScanInitial,
+    TResult Function()? burnScanLoading,
+    TResult Function(BurnAnalysisResponseModel response)? burnScanSuccess,
+    TResult Function(String error)? burnScanError,
+    required TResult orElse(),
+  }) {
+    if (burnScanSuccess != null) {
+      return burnScanSuccess(response);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_burnScanInitial<T> value) burnScanInitial,
+    required TResult Function(burnScanLoading<T> value) burnScanLoading,
+    required TResult Function(burnScanSuccess<T> value) burnScanSuccess,
+    required TResult Function(burnScanError<T> value) burnScanError,
+  }) {
+    return burnScanSuccess(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_burnScanInitial<T> value)? burnScanInitial,
+    TResult? Function(burnScanLoading<T> value)? burnScanLoading,
+    TResult? Function(burnScanSuccess<T> value)? burnScanSuccess,
+    TResult? Function(burnScanError<T> value)? burnScanError,
+  }) {
+    return burnScanSuccess?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_burnScanInitial<T> value)? burnScanInitial,
+    TResult Function(burnScanLoading<T> value)? burnScanLoading,
+    TResult Function(burnScanSuccess<T> value)? burnScanSuccess,
+    TResult Function(burnScanError<T> value)? burnScanError,
+    required TResult orElse(),
+  }) {
+    if (burnScanSuccess != null) {
+      return burnScanSuccess(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class burnScanSuccess<T> implements BurnScanState<T> {
+  const factory burnScanSuccess(final BurnAnalysisResponseModel response) =
+      _$burnScanSuccessImpl<T>;
+
+  BurnAnalysisResponseModel get response;
+
+  /// Create a copy of BurnScanState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$burnScanSuccessImplCopyWith<T, _$burnScanSuccessImpl<T>> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$burnScanErrorImplCopyWith<T, $Res> {
+  factory _$$burnScanErrorImplCopyWith(_$burnScanErrorImpl<T> value,
+          $Res Function(_$burnScanErrorImpl<T>) then) =
+      __$$burnScanErrorImplCopyWithImpl<T, $Res>;
+  @useResult
+  $Res call({String error});
+}
+
+/// @nodoc
+class __$$burnScanErrorImplCopyWithImpl<T, $Res>
+    extends _$BurnScanStateCopyWithImpl<T, $Res, _$burnScanErrorImpl<T>>
+    implements _$$burnScanErrorImplCopyWith<T, $Res> {
+  __$$burnScanErrorImplCopyWithImpl(_$burnScanErrorImpl<T> _value,
+      $Res Function(_$burnScanErrorImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of BurnScanState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? error = null,
+  }) {
+    return _then(_$burnScanErrorImpl<T>(
+      null == error
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$burnScanErrorImpl<T> implements burnScanError<T> {
+  const _$burnScanErrorImpl(this.error);
+
+  @override
+  final String error;
+
+  @override
+  String toString() {
+    return 'BurnScanState<$T>.burnScanError(error: $error)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$burnScanErrorImpl<T> &&
+            (identical(other.error, error) || other.error == error));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, error);
+
+  /// Create a copy of BurnScanState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$burnScanErrorImplCopyWith<T, _$burnScanErrorImpl<T>> get copyWith =>
+      __$$burnScanErrorImplCopyWithImpl<T, _$burnScanErrorImpl<T>>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() burnScanInitial,
+    required TResult Function() burnScanLoading,
+    required TResult Function(BurnAnalysisResponseModel response)
+        burnScanSuccess,
+    required TResult Function(String error) burnScanError,
+  }) {
+    return burnScanError(error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? burnScanInitial,
+    TResult? Function()? burnScanLoading,
+    TResult? Function(BurnAnalysisResponseModel response)? burnScanSuccess,
+    TResult? Function(String error)? burnScanError,
+  }) {
+    return burnScanError?.call(error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? burnScanInitial,
+    TResult Function()? burnScanLoading,
+    TResult Function(BurnAnalysisResponseModel response)? burnScanSuccess,
+    TResult Function(String error)? burnScanError,
+    required TResult orElse(),
+  }) {
+    if (burnScanError != null) {
+      return burnScanError(error);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_burnScanInitial<T> value) burnScanInitial,
+    required TResult Function(burnScanLoading<T> value) burnScanLoading,
+    required TResult Function(burnScanSuccess<T> value) burnScanSuccess,
+    required TResult Function(burnScanError<T> value) burnScanError,
+  }) {
+    return burnScanError(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_burnScanInitial<T> value)? burnScanInitial,
+    TResult? Function(burnScanLoading<T> value)? burnScanLoading,
+    TResult? Function(burnScanSuccess<T> value)? burnScanSuccess,
+    TResult? Function(burnScanError<T> value)? burnScanError,
+  }) {
+    return burnScanError?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_burnScanInitial<T> value)? burnScanInitial,
+    TResult Function(burnScanLoading<T> value)? burnScanLoading,
+    TResult Function(burnScanSuccess<T> value)? burnScanSuccess,
+    TResult Function(burnScanError<T> value)? burnScanError,
+    required TResult orElse(),
+  }) {
+    if (burnScanError != null) {
+      return burnScanError(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class burnScanError<T> implements BurnScanState<T> {
+  const factory burnScanError(final String error) = _$burnScanErrorImpl<T>;
+
+  String get error;
+
+  /// Create a copy of BurnScanState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$burnScanErrorImplCopyWith<T, _$burnScanErrorImpl<T>> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/burn_scan/ui/screens/burn_scan_screen.dart
+++ b/lib/features/burn_scan/ui/screens/burn_scan_screen.dart
@@ -1,15 +1,21 @@
 import 'dart:io';
-
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:nexus/core/constants/assets.dart';
+import 'package:nexus/core/helpers/base_extensions/context/navigation.dart';
 import 'package:nexus/core/helpers/base_extensions/context/padding.dart';
 import 'package:nexus/core/widgets/app_text_button.dart';
 import 'package:nexus/core/widgets/custom_header.dart';
 import 'package:nexus/core/helpers/helper_methods/spacing.dart';
 import 'package:nexus/core/theming/app_styles.dart';
 import 'package:nexus/core/theming/colors_manager.dart';
+import 'package:nexus/features/burn_scan/logic/burn_scan_cubit.dart';
+
+import '../../../../core/animations/custom_loading_indicator.dart';
+import '../../../../core/routing/routes.dart';
+import '../../logic/burn_scan_state.dart';
 
 class BurnScanScreen extends StatefulWidget {
   const BurnScanScreen({super.key});
@@ -96,105 +102,137 @@ class _BurnScanScreenState extends State<BurnScanScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: SafeArea(
-        child: Column(
-          children: [
-            verticalSpace(40),
-            const CustomHeader(text: 'Burn Scan'),
-            verticalSpace(119),
-            if (_selectedImage != null)
-              Stack(
-                children: [
-                  ClipRRect(
-                    borderRadius: BorderRadius.circular(12.0),
-                    child: Image.file(
-                      _selectedImage!,
-                      width: 250.w,
-                      height: 250.h,
-                      fit: BoxFit.cover,
-                    ),
-                  ),
-                  Positioned(
-                    top: 8,
-                    left: 8,
-                    child: GestureDetector(
-                      onTap: () {
-                        setState(() {
-                          _selectedImage = null;
-                        });
-                      },
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: Colors.black.withOpacity(0.5),
-                          shape: BoxShape.circle,
-                        ),
-                        child: const Icon(
-                          Icons.close,
-                          color: Colors.white,
-                          size: 28,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              )
-            else
-              Stack(
-                alignment: Alignment.center,
-                children: [
-                  Container(
-                    width: 130.w,
-                    height: 130.h,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: ColorsManager.appColor.withOpacity(0.15),
-                    ),
-                  ),
-                  Container(
-                    width: 109.w,
-                    height: 109.h,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: ColorsManager.appColor.withOpacity(0.38),
-                    ),
-                  ),
-                  Container(
-                    width: 90.w,
-                    height: 90.h,
-                    decoration: const BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: ColorsManager.appColor,
-                    ),
-                    child: Center(
-                      child: Image.asset(
-                        Assets.iconsScanInlined,
-                        width: 45.w,
-                        height: 45.h,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            verticalSpace(42),
-            Text(
-              _selectedImage == null
-                  ? 'Please show your burn hand to scan it'
-                  : 'Image selected. Ready to analyze.',
-              style: AppStyles.aldrichRegular14Violet50.copyWith(
-                color: ColorsManager.violet200,
-              ),
-            ),
-            verticalSpace(122),
-            AppTextButton(
-              text: _selectedImage == null ? 'Get Started' : 'Analyze Burn',
-              onPressed: () {
-                if (_selectedImage == null) {
-                  _showImageOptionsBottomSheet(context);
-                } else {
-                  //  analysis logic
-                }
+        child: BlocConsumer<BurnScanCubit, BurnScanState>(
+          buildWhen: (previous, current) =>
+              current is burnScanLoading ||
+              current is burnScanSuccess ||
+              current is burnScanError,
+          listener: (context, state) {
+            state.whenOrNull(
+              burnScanSuccess: (response) {
+                final burnDetails = response.result;
+                context.pushNamed(
+                  Routes.classificationScreen,
+                  arguments: burnDetails,
+                );
               },
-            ),
-          ],
+              burnScanError: (errorMsg) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text(errorMsg),
+                  ),
+                );
+              },
+            );
+          },
+          builder: (context, state) {
+            final isLoading = state is burnScanLoading;
+
+            return Column(
+              children: [
+                verticalSpace(40),
+                const CustomHeader(text: 'Burn Scan'),
+                verticalSpace(119),
+                if (isLoading)
+                  const CustomLoadingIndicator(text: 'Analyzing...')
+                else if (_selectedImage != null)
+                  Stack(
+                    children: [
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(12.0),
+                        child: Image.file(
+                          _selectedImage!,
+                          width: 250.w,
+                          height: 250.h,
+                          fit: BoxFit.cover,
+                        ),
+                      ),
+                      Positioned(
+                        top: 8,
+                        left: 8,
+                        child: GestureDetector(
+                          onTap: () {
+                            setState(() {
+                              _selectedImage = null;
+                            });
+                          },
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: Colors.black.withOpacity(0.5),
+                              shape: BoxShape.circle,
+                            ),
+                            child: const Icon(
+                              Icons.close,
+                              color: Colors.white,
+                              size: 28,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  )
+                else
+                  Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      Container(
+                        width: 130.w,
+                        height: 130.h,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: ColorsManager.appColor.withOpacity(0.15),
+                        ),
+                      ),
+                      Container(
+                        width: 109.w,
+                        height: 109.h,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: ColorsManager.appColor.withOpacity(0.38),
+                        ),
+                      ),
+                      Container(
+                        width: 90.w,
+                        height: 90.h,
+                        decoration: const BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: ColorsManager.appColor,
+                        ),
+                        child: Center(
+                          child: Image.asset(
+                            Assets.iconsScanInlined,
+                            width: 45.w,
+                            height: 45.h,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                verticalSpace(42),
+                Text(
+                  _selectedImage == null
+                      ? 'Please show your burn hand to scan it'
+                      : 'Image selected. Ready to analyze.',
+                  style: AppStyles.aldrichRegular14Violet50.copyWith(
+                    color: ColorsManager.violet200,
+                  ),
+                ),
+                verticalSpace(122),
+                AppTextButton(
+                  text: _selectedImage == null ? 'Get Started' : 'Analyze Burn',
+                  onPressed: () {
+                    if (_selectedImage == null) {
+                      _showImageOptionsBottomSheet(context);
+                    } else {
+                      context
+                          .read<BurnScanCubit>()
+                          .analyzeBurn(_selectedImage!);
+                    }
+                  },
+                ),
+              ],
+            );
+          },
         ),
       ),
     );

--- a/lib/features/burn_scan/ui/screens/classification_screen.dart
+++ b/lib/features/burn_scan/ui/screens/classification_screen.dart
@@ -7,65 +7,26 @@ import 'package:nexus/core/theming/colors_manager.dart';
 import 'package:nexus/core/widgets/custom_header.dart';
 
 import '../../../../core/constants/assets.dart';
-
-// A simple model to hold the classification data.
-class BurnData {
-  final String classification;
-  final String severity;
-  final String confidence;
-  final String description;
-  final List<String> symptoms;
-  final List<String> treatment;
-  final String healingTime;
-  final List<String> whenToSeekHelp;
-
-  BurnData({
-    required this.classification,
-    required this.severity,
-    required this.confidence,
-    required this.description,
-    required this.symptoms,
-    required this.treatment,
-    required this.healingTime,
-    required this.whenToSeekHelp,
-  });
-}
+import '../../data/models/burn_analysis_response_model.dart';
 
 class ClassificationScreen extends StatelessWidget {
-  const ClassificationScreen({super.key});
+  final BurnResult burnDetails;
+  const ClassificationScreen({
+    super.key,
+    required this.burnDetails,
+  });
+
+  Color _parseColor(String colorString) {
+    try {
+      return Color(int.parse(colorString.replaceFirst('#', '0xFF')));
+    } catch (e) {
+      // Return a default color if parsing fails
+      return ColorsManager.mariGold;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    // --- MOCK DATA: Replace this with actual data from your model ---
-    final burnData = BurnData(
-      classification: 'Second-Degree Burn',
-      severity: 'MODERATE TO SEVERE',
-      confidence: '100%',
-      description:
-          'Second-degree burns affect both the outer layer and the underlying dermis. They cause pain, redness, swelling, and blistering.',
-      symptoms: [
-        'Deep redness and swelling',
-        'Blisters that may open',
-        'Wet or shiny appearance',
-        'Severe pain and tenderness',
-        'Fever if burn area is large',
-      ],
-      treatment: [
-        'Cool the area with running water for 15–20 minutes',
-        'Do NOT pop blisters',
-        'Apply antibiotic ointment (if recommended)',
-        'Cover with sterile, non-stick bandage',
-        'Stay hydrated and monitor for infection',
-      ],
-      healingTime: 'Expected healing time: 2–3 weeks.',
-      whenToSeekHelp: [
-        'If the burn is larger than 3 inches',
-        'Signs of infection (pus, fever, swelling)',
-        'If the burn is on face, hands, feet, or joints',
-      ],
-    );
-    // --- END OF MOCK DATA ---
-
     return Scaffold(
       body: Stack(
         children: [
@@ -86,7 +47,7 @@ class ClassificationScreen extends StatelessWidget {
                   verticalSpace(28),
                   CustomHeader(
                     padding: 0,
-                    text: 'Classification:\n ${burnData.classification}',
+                    text: 'Classification:\n ${burnDetails.classification}',
                   ),
                   verticalSpace(35),
                   // Severity Tag
@@ -95,28 +56,28 @@ class ClassificationScreen extends StatelessWidget {
                       padding:
                           context.symmetric(horizontal: 14.w, vertical: 12.h),
                       decoration: BoxDecoration(
-                        color: ColorsManager.mariGold,
+                        color: _parseColor(burnDetails.color).withOpacity(0.8),
                         borderRadius: BorderRadius.circular(12.r),
                       ),
                       child: Text(
-                        burnData.severity,
+                        burnDetails.severity.toUpperCase(),
                         style: AppStyles.aldrichRegular14Violet50
                             .copyWith(color: ColorsManager.kohlDust),
                       ),
                     ),
                   ),
                   verticalSpace(35),
-                  // Confidence and Warning
                   Text(
-                    'Confidence: ${burnData.confidence}',
+                    'Confidence: ${burnDetails.confidence}',
                     style: AppStyles.aldrichRegular14Violet50
                         .copyWith(color: ColorsManager.darkGray),
                   ),
                   verticalSpace(8),
                   Text(
                     'This burn may require medical attention depending on size and symptoms. Please monitor closely.',
-                    style: AppStyles.aldrichRegular14Violet50
-                        .copyWith(color: ColorsManager.mariGold),
+                    style: AppStyles.aldrichRegular14Violet50.copyWith(
+                      color: ColorsManager.mariGold,
+                    ),
                   ),
                   verticalSpace(30),
                   // Sections
@@ -124,7 +85,7 @@ class ClassificationScreen extends StatelessWidget {
                     context,
                     title: '📝 Description',
                     content: Text(
-                      burnData.description,
+                      burnDetails.description,
                       style: AppStyles.aldrichRegular14Violet50.copyWith(
                         color: Colors.white,
                       ),
@@ -132,19 +93,19 @@ class ClassificationScreen extends StatelessWidget {
                   ),
                   _buildSection(
                     context,
-                    title: '🩺 Symptoms',
-                    content: _buildBulletPointList(burnData.symptoms),
+                    title: '🤕 Symptoms',
+                    content: _buildBulletPointList(burnDetails.symptoms),
                   ),
                   _buildSection(
                     context,
                     title: '🧯 How to Treat',
-                    content: _buildBulletPointList(burnData.treatment),
+                    content: _buildBulletPointList(burnDetails.treatment),
                   ),
                   _buildSection(
                     context,
                     title: '⏳ Healing Time',
                     content: Text(
-                      burnData.healingTime,
+                      'Expected healing time: ${burnDetails.healingTime}',
                       style: AppStyles.aldrichRegular14Violet50.copyWith(
                         color: Colors.white,
                       ),
@@ -153,7 +114,12 @@ class ClassificationScreen extends StatelessWidget {
                   _buildSection(
                     context,
                     title: '🚨 When to Seek Medical Help',
-                    content: _buildBulletPointList(burnData.whenToSeekHelp),
+                    content: Text(
+                      burnDetails.whenToSeekHelp,
+                      style: AppStyles.aldrichRegular14Violet50.copyWith(
+                        color: Colors.white,
+                      ),
+                    ),
                   ),
                   verticalSpace(40),
                   // Disclaimer


### PR DESCRIPTION
- Added `analyzeBurn` method in `ApiService` to handle image uploads for burn analysis.
- Integrated `BurnScanCubit` to manage state during the burn analysis process.
- Created `BurnScanRepo` to interact with the API and handle responses.
- Updated `BurnScanScreen` to allow users to select an image and trigger analysis.
- Implemented `ClassificationScreen` to display results of the burn analysis.
- Defined data models for API responses, including `BurnAnalysisResponseModel` and `BurnResult`.
- Enhanced routing to include new screens and pass necessary data.
- Added error handling for API calls and state management using Freezed.